### PR TITLE
Add globalized highlight-parentheses-mode

### DIFF
--- a/highlight-parentheses.el
+++ b/highlight-parentheses.el
@@ -128,6 +128,10 @@ This is used to prevent analyzing the same context over and over.")
     (hl-paren-create-overlays)
     (add-hook 'post-command-hook 'hl-paren-highlight nil t)))
 
+(define-globalized-minor-mode global-highlight-parentheses-mode
+  highlight-parentheses-mode
+  (lambda () (highlight-parentheses-mode 1)))
+
 ;;; overlays ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun hl-paren-create-overlays ()


### PR DESCRIPTION
Adding globalized mode may help some people, including me, who want to use highlight-parentheses-mode in all buffers.
Thanks.
