### PR TITLE
Delete overlays when needed, face attributes for parens.

### DIFF
--- a/highlight-parentheses.el
+++ b/highlight-parentheses.el
@@ -83,6 +83,9 @@ This is used to prevent analyzing the same context over and over.")
   "A timer initiating the movement of the `hl-paren-overlays'.")
 (make-variable-buffer-local 'hl-paren-timer)
 
+(defun* hl-paren-delete-overlays (&optional (overlays hl-paren-overlays))
+  (mapc #'delete-overlay overlays))
+
 (defun hl-paren-highlight ()
   "Highlight the parentheses around point."
   (unless (= (point) hl-paren-last-point)
@@ -99,7 +102,7 @@ This is used to prevent analyzing the same context over and over.")
                 (move-overlay (pop overlays) (1- pos2) pos2)))
           (error nil))
         (goto-char pos))
-      (mapc #'delete-overlay overlays))))
+      (hl-paren-delete-overlays overlays))))
 
 (defcustom hl-paren-delay 0.137
   "Fraction of seconds after which the `hl-paren-overlays' are adjusted.
@@ -120,17 +123,21 @@ overlays when scrolling or moving point by pressing and holding
 (define-minor-mode highlight-parentheses-mode
   "Minor mode to highlight the surrounding parentheses."
   nil " hl-p" nil
-  (mapc 'delete-overlay hl-paren-overlays)
+  (hl-paren-delete-overlays)
   (kill-local-variable 'hl-paren-overlays)
   (kill-local-variable 'hl-paren-last-point)
   (remove-hook 'post-command-hook 'hl-paren-initiate-highlight t)
+  (remove-hook 'before-revert-hook 'hl-paren-delete-overlays)
+  (remove-hook 'change-major-mode-hook 'hl-paren-delete-overlays)
   (when (and highlight-parentheses-mode
              ;; Don't enable in *Messages* buffer.
              ;; https://github.com/tsdh/highlight-parentheses.el/issues/14
              (not (eq major-mode 'messages-buffer-mode))
              (not (string= (buffer-name) "*Messages*")))
     (hl-paren-create-overlays)
-    (add-hook 'post-command-hook 'hl-paren-initiate-highlight nil t)))
+    (add-hook 'post-command-hook 'hl-paren-initiate-highlight nil t)
+    (add-hook 'before-revert-hook 'hl-paren-delete-overlays)
+    (add-hook 'change-major-mode-hook 'hl-paren-delete-overlays)))
 
 ;;;###autoload
 (define-globalized-minor-mode global-highlight-parentheses-mode
@@ -160,7 +167,7 @@ overlays when scrolling or moving point by pressing and holding
   (dolist (buffer (buffer-list))
     (with-current-buffer buffer
       (when hl-paren-overlays
-        (mapc 'delete-overlay hl-paren-overlays)
+        (hl-paren-delete-overlays)
         (setq hl-paren-overlays nil)
         (hl-paren-create-overlays)
         (let ((hl-paren-last-point -1)) ;; force update

--- a/highlight-parentheses.el
+++ b/highlight-parentheses.el
@@ -51,21 +51,21 @@
   '("firebrick1" "IndianRed1" "IndianRed3" "IndianRed4")
   "List of colors for the highlighted parentheses.
 The list starts with the inside parentheses and moves outwards."
-  :type '(repeat color)
+  :type '(choice (repeat color) function)
   :set 'hl-paren-set
   :group 'highlight-parentheses)
 
 (defcustom hl-paren-background-colors nil
   "List of colors for the background highlighted parentheses.
 The list starts with the inside parentheses and moves outwards."
-  :type '(repeat color)
+  :type '(choice (repeat color) function)
   :set 'hl-paren-set
   :group 'highlight-parentheses)
 
 (defcustom hl-paren-attributes nil
   "List of face attributes for the highlighted parentheses.
 The list starts with the inside parentheses and moves outwards."
-  :type plist
+  :type '(choice plist function)
   :set 'hl-paren-set
   :group 'highlight-parentheses)
 
@@ -154,9 +154,15 @@ overlays when scrolling or moving point by pressing and holding
 ;;; overlays ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun hl-paren-create-overlays ()
-  (let ((fg hl-paren-colors)
-        (bg hl-paren-background-colors)
-        (attr hl-paren-attributes)
+  (let ((fg (if (functionp hl-paren-colors)
+                (funcall hl-paren-colors)
+              hl-paren-colors))
+        (bg (if (functionp hl-paren-background-colors)
+                (funcall hl-paren-background-colors)
+              hl-paren-background-colors))
+        (attr (if (functionp hl-paren-attributes)
+                  (funcall hl-paren-attributes)
+                hl-paren-attributes))
         attributes)
     (while (or fg bg attr)
       (setq attributes (face-attr-construct 'hl-paren-face))

--- a/highlight-parentheses.el
+++ b/highlight-parentheses.el
@@ -50,15 +50,22 @@
 (defcustom hl-paren-colors
   '("firebrick1" "IndianRed1" "IndianRed3" "IndianRed4")
   "List of colors for the highlighted parentheses.
-The list starts with the the inside parentheses and moves outwards."
+The list starts with the inside parentheses and moves outwards."
   :type '(repeat color)
   :set 'hl-paren-set
   :group 'highlight-parentheses)
 
 (defcustom hl-paren-background-colors nil
   "List of colors for the background highlighted parentheses.
-The list starts with the the inside parentheses and moves outwards."
+The list starts with the inside parentheses and moves outwards."
   :type '(repeat color)
+  :set 'hl-paren-set
+  :group 'highlight-parentheses)
+
+(defcustom hl-paren-attributes nil
+  "List of face attributes for the highlighted parentheses.
+The list starts with the inside parentheses and moves outwards."
+  :type plist
   :set 'hl-paren-set
   :group 'highlight-parentheses)
 
@@ -149,15 +156,23 @@ overlays when scrolling or moving point by pressing and holding
 (defun hl-paren-create-overlays ()
   (let ((fg hl-paren-colors)
         (bg hl-paren-background-colors)
+        (attr hl-paren-attributes)
         attributes)
-    (while (or fg bg)
+    (while (or fg bg attr)
       (setq attributes (face-attr-construct 'hl-paren-face))
-      (when (car fg)
-        (setq attributes (plist-put attributes :foreground (car fg))))
+      (let ((car-fg (car fg))
+            (car-bg (car bg))
+            (car-attr (car attr)))
+        (loop for (key . (val . _rest)) on car-attr by #'cddr
+              do (setq attributes
+                       (plist-put attributes key val)))
+        (when car-fg
+          (setq attributes (plist-put attributes :foreground car-fg)))
+        (when car-bg
+          (setq attributes (plist-put attributes :background car-bg))))
       (pop fg)
-      (when (car bg)
-        (setq attributes (plist-put attributes :background (car bg))))
       (pop bg)
+      (pop attr)
       (dotimes (i 2) ;; front and back
         (push (make-overlay 0 0 nil t) hl-paren-overlays)
         (overlay-put (car hl-paren-overlays) 'font-lock-face attributes)))


### PR DESCRIPTION
Example of usage:
```elisp
(with-eval-after-load "highlight-parentheses-autoloads"
  (setq hl-paren-background-colors
        #'(lambda ()
            (if (eq (frame-parameter (selected-frame) 'background-mode)
                    'light)
                '("#FFF" "#DDCCDD" "#CCDDDD")
              '("#333" "#444" "#555"))))
  (setq hl-paren-colors '("#FF0000" "#FF00FF" "#00FFFF"))
  (setq hl-paren-attributes '((:height 1.1 :weight bold)))
  (global-highlight-parentheses-mode t))
```