### PR TITLE
Optionally highlight adjacent parens

### DIFF
--- a/highlight-parentheses.el
+++ b/highlight-parentheses.el
@@ -109,9 +109,9 @@ This is used to prevent analyzing the same context over and over.")
       (save-excursion
         (ignore-errors
           (when hl-paren-highlight-adjacent
-            (cond ((memq (preceding-char) '(?\) ?\} ?\]))
+            (cond ((memq (preceding-char) '(?\) ?\} ?\] ?\>))
                    (backward-char 1))
-                  ((memq (following-char) '(?\( ?\{ ?\[))
+                  ((memq (following-char) '(?\( ?\{ ?\[ ?\<))
                    (forward-char 1))))
           (while (and (setq pos1 (cadr (syntax-ppss pos1)))
                       (cdr overlays))

--- a/highlight-parentheses.el
+++ b/highlight-parentheses.el
@@ -109,9 +109,9 @@ This is used to prevent analyzing the same context over and over.")
       (save-excursion
         (ignore-errors
           (when hl-paren-highlight-adjacent
-            (cond ((eq ?\) (preceding-char))
+            (cond ((memq (preceding-char) '(?\) ?\} ?\]))
                    (backward-char 1))
-                  ((eq ?\( (following-char))
+                  ((memq (following-char) '(?\( ?\{ ?\[))
                    (forward-char 1))))
           (while (and (setq pos1 (cadr (syntax-ppss pos1)))
                       (cdr overlays))

--- a/highlight-parentheses.el
+++ b/highlight-parentheses.el
@@ -1,6 +1,7 @@
 ;;; highlight-parentheses.el --- highlight surrounding parentheses
 ;;
 ;; Copyright (C) 2007, 2009, 2013 Nikolaj Schumacher
+;; Copyright (C) 2018 Tim Perkins
 ;;
 ;; Author: Nikolaj Schumacher <bugs * nschum de>
 ;; Maintainer: Tassilo Horn <tsdh@gnu.org>
@@ -69,6 +70,12 @@ The list starts with the inside parentheses and moves outwards."
   :set 'hl-paren-set
   :group 'highlight-parentheses)
 
+(defcustom hl-paren-highlight-adjacent nil
+  "Highlight adjacent parentheses, just like show-paren-mode."
+  :type '(boolean)
+  :set 'hl-paren-set
+  :group 'highlight-parentheses)
+
 (defface hl-paren-face nil
   "Face used for highlighting parentheses.
 Color attributes might be overriden by `hl-paren-colors' and
@@ -98,17 +105,19 @@ This is used to prevent analyzing the same context over and over.")
   (unless (= (point) hl-paren-last-point)
     (setq hl-paren-last-point (point))
     (let ((overlays hl-paren-overlays)
-          pos1 pos2
-          (pos (point)))
+          pos1 pos2)
       (save-excursion
-        (condition-case err
-            (while (and (setq pos1 (cadr (syntax-ppss pos1)))
-                        (cdr overlays))
-              (move-overlay (pop overlays) pos1 (1+ pos1))
-              (when (setq pos2 (scan-sexps pos1 1))
-                (move-overlay (pop overlays) (1- pos2) pos2)))
-          (error nil))
-        (goto-char pos))
+        (ignore-errors
+          (when hl-paren-highlight-adjacent
+            (cond ((eq ?\) (preceding-char))
+                   (backward-char 1))
+                  ((eq ?\( (following-char))
+                   (forward-char 1))))
+          (while (and (setq pos1 (cadr (syntax-ppss pos1)))
+                      (cdr overlays))
+            (move-overlay (pop overlays) pos1 (1+ pos1))
+            (when (setq pos2 (scan-sexps pos1 1))
+              (move-overlay (pop overlays) (1- pos2) pos2)))))
       (hl-paren-delete-overlays overlays))))
 
 (defcustom hl-paren-delay 0.137


### PR DESCRIPTION
Adds an option to highlight adjacent parenthesis to point, similarly to `show-paren-mode`.

It works by testing the characters before and after point for characters used to end and begin sexps respectively, and then moves into that sexp if there was one. For example, if the character before point is `)`, we move one character backwards and then do the usual highlighting code.

At this point you may be thinking, "Hey, obviously this doesn't work when the character isn't actually at the boundary of a sexp!" But the nice thing about this is that it doesn't actually matter, because the error is benign. If the character is a false positive, the move is still in the sexp. (Unless you're working with a really bizarre language that does `)reverse parens(` or something.)

I actually wrote this code a while ago (and have been using it for years). But when I originally submitted the PR, `nschum` never responded and I just closed it. Seeing that there is now a new maintainer, maybe we could get it merged this time?

I would be happy to make changes, just let me know.